### PR TITLE
Cleanup Transformer Benchmarks

### DIFF
--- a/benchmarks/Transformers/BM25TransformerBench.php
+++ b/benchmarks/Transformers/BM25TransformerBench.php
@@ -15,6 +15,16 @@ class BM25TransformerBench
     protected const NUM_SAMPLES = 10000;
 
     /**
+     * @var \Rubix\ML\Datasets\Unlabeled
+     */
+    public $dataset;
+
+    /**
+     * @var \Rubix\ML\Transformers\BM25Transformer
+     */
+    protected $transformer;
+
+    /**
      * @var array[]
      */
     protected $aSamples;

--- a/benchmarks/Transformers/BM25TransformerBench.php
+++ b/benchmarks/Transformers/BM25TransformerBench.php
@@ -17,7 +17,7 @@ class BM25TransformerBench
     /**
      * @var \Rubix\ML\Datasets\Unlabeled
      */
-    public $dataset;
+    protected $dataset;
 
     /**
      * @var \Rubix\ML\Transformers\BM25Transformer

--- a/benchmarks/Transformers/DeltaTfIdfTransformerBench.php
+++ b/benchmarks/Transformers/DeltaTfIdfTransformerBench.php
@@ -18,7 +18,7 @@ class DeltaTfIdfTransformerBench
     /**
      * @var \Rubix\ML\Datasets\Labeled
      */
-    public $dataset;
+    protected $dataset;
 
     /**
      * @var \Rubix\ML\Transformers\DeltaTfIdfTransformer

--- a/benchmarks/Transformers/TokenHashingVectorizerBench.php
+++ b/benchmarks/Transformers/TokenHashingVectorizerBench.php
@@ -16,6 +16,16 @@ class TokenHashingVectorizerBench
     protected const SAMPLE_TEXT = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec at nisl posuere, luctus sapien vel, maximus ex. Curabitur tincidunt, libero at commodo tempor, magna neque malesuada diam, vel blandit metus velit quis magna. Vestibulum auctor libero quam, eu ullamcorper nulla dapibus a. Mauris id ultricies sapien. Integer consequat mi eget vehicula vulputate. Mauris cursus nisi non semper dictum. Quisque luctus ex in tortor laoreet tincidunt. Vestibulum imperdiet purus sit amet sapien dignissim elementum. Mauris tincidunt eget ex eu laoreet. Etiam efficitur quam at purus sagittis hendrerit. Mauris tempus, sem in pulvinar imperdiet, lectus ipsum molestie ante, id semper nunc est sit amet sem. Nulla at justo eleifend, gravida neque eu, consequat arcu. Vivamus bibendum eleifend metus, id elementum orci aliquet ac. Praesent pellentesque nisi vitae tincidunt eleifend. Pellentesque quis ex et lorem laoreet hendrerit ut ac lorem. Aliquam non sagittis est.';
 
     /**
+     * @var \Rubix\ML\Datasets\Dataset
+     */
+    protected $dataset;
+
+    /**
+     * @var \Rubix\ML\Transformers\TokenHashingVectorizer
+     */
+    protected $transformer;
+
+    /**
      * @var array[]
      */
     protected $aSamples;


### PR DESCRIPTION
###### SUMMARY:

Small cleanups adding some undefined properties in the `BM25TransformerBench`, and `TokenHashingVectorizerBench` classes, and moving `DeltaTfIdfTransformerBench.php` into the `benchmarks/Transformers/` directory.